### PR TITLE
Add database_cleaner and email-spec to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Friendly English-like interface for your command line. Written in Ruby. [Ruby]
 #### [CombinePDF](https://github.com/boazsegev/combine_pdf)
 PDF merging, stamping, numbering and simple editing. Pure Ruby (no dependencies). [Ruby]
 
+#### [DatabaseCleaner](https://github.com/DatabaseCleaner/database_cleaner)
+Strategies for cleaning databases. Can be used to ensure a clean state for testing. [Ruby]
+
+#### [EmailSpec](https://github.com/email-spec/email-spec/)
+Collection of RSpec/MiniTest matchers and Cucumber steps for testing email in a ruby app using ActionMailer or Pony. [Ruby]
+
 #### [forem](https://github.com/rubysherpas/forem)
 Rails 3 and Rails 4 forum engine. [Ruby] [Rails]
 


### PR DESCRIPTION
Hey @pickhardt, 

I'm looking for co-maintainers of `database_cleaner` and `email-spec`

Right now I'm the lead maintainer of both of them and I'd like to get help from other developers not just as contributors but as co-maintainers.

Please let me know if you have any questions. 

Thanks! 