### PR TITLE
Remove Forem

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ Strategies for cleaning databases. Can be used to ensure a clean state for testi
 #### [EmailSpec](https://github.com/email-spec/email-spec/)
 Collection of RSpec/MiniTest matchers and Cucumber steps for testing email in a ruby app using ActionMailer or Pony. [Ruby]
 
-#### [forem](https://github.com/rubysherpas/forem)
-Rails 3 and Rails 4 forum engine. [Ruby] [Rails]
-
 #### [FireSharp](https://github.com/ziyasal/FireSharp)
 An asynchronous .Net client library for Firebase. [C#] [Mono]
 


### PR DESCRIPTION
As per @radar's [commit](https://github.com/rubysherpas/forem/commit/fb37858a51cfc8fe2ccd113e61af42546091fd27):

 
<img width="954" alt="screen shot 2018-11-28 at 4 29 00 pm" src="https://user-images.githubusercontent.com/6392429/49183462-efabf480-f32a-11e8-85c4-d2ebc5db5bf6.png">


I think it makes sense to remove this project.

The requirements for accepting a new project are simple: