### PR TITLE
Add gpodder.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Git extensions to provide high-level repository operations for [Vincent Driessen
 #### [gitx](https://github.com/pieter/gitx)
 GitX is a git GUI made for Mac OS X. [Objective C]
 
+#### [gpodder.net](https://github.com/gpodder/mygpo)
+The gpodder.net podcast webservice. [Python]
+
 #### [grunt-phantomas](https://github.com/stefanjudis/grunt-phantomas)
 Grunt plugin to visualize performance metrics evaluated by Phantomas. [JS]
 


### PR DESCRIPTION
I am a former contributor to the gpodder.net project.

The project's creator - @stefankoegl hasn't enough time to maintain it since late 2019. Now, @fundatillus is taking care of the community issues and keeping the project alive.

But the project needs an active maintainer who has the capability to handle bugs timely and develop features, which has been stalled for almost 2 years.
